### PR TITLE
fix/Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,8 @@
-default: target/release/display-switch
+default: target/release/display-switch /opt/homebrew/bin/displayplacer
 
 target/release/display-switch: \
 	Cargo.toml Cargo.lock \
-	src/main.rs src/placer.rs src/store.rs \
-	/opt/homebrew/bin/displayplacer
+	src/main.rs src/placer.rs src/store.rs
 	cargo build --release
 
 /opt/homebrew/bin/displayplacer: /opt/homebrew/bin/brew

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This command memorizes and switches between multiple display placement settings.
 
 ## Installation
 
-Clone the repository and run the following command (cargo and brew commands are required).
+Clone the repository and run the following command (cargo, brew and displayplacer commands are required).
 
 ```
 make


### PR DESCRIPTION
- **📝 (Makefile): remove unnecessary dependency on /opt/homebrew/bin/displayplacer to simplify build process and improve maintainability**
- **📝 (README.md): update installation instructions to include displayplacer command as a requirement for running the app**
